### PR TITLE
Fix Mistral key checking

### DIFF
--- a/Mistral.py
+++ b/Mistral.py
@@ -13,15 +13,15 @@ async def check_sub_status(key: APIKey, session):
     data = {
         'model': 'open-mistral-7b',
         'messages': [{'role': 'user', 'content': ''}],
-        'max_tokens': 1
+        'max_tokens': -1
     }
     async with session.post(f'https://api.mistral.ai/v1/chat/completions', headers={'Authorization': f'Bearer {key.api_key}'}, json=data) as response:
-        if response.status == 401 or response.status == 429:
-            return False
-        return True
+        # Since we do an invalid request, if the key is active and has quota, the API returns 422 Unprocessable Entity
+        return response.status == 422
 
 
 def pretty_print_mistral_keys(keys):
+    keys = sorted(keys, key=lambda x: x.subbed, reverse=True)
     print('-' * 90)
     subbed = 0
     print(f'Validated {len(keys)} Mistral keys:')


### PR DESCRIPTION
Previous code wasn't checking sub status properly since Mistral API returns 403 on a key that doesn't have a working sub. I made it better anyhow, using roughly the same trick as with OpenAI by providing `max_tokens` at -1 so that the API doesn't bill any usage, but we can still determine if the key is working properly - the API only returns 422 if the key can request the model, otherwise it's some other status code that we don't care about. Also added sorting by sub status.