### PR TITLE
Fix OpenAI regex

### DIFF
--- a/main.py
+++ b/main.py
@@ -196,7 +196,7 @@ async def execute_with_retries(func, key, sem, retries):
             break
 
 
-oai_regex = re.compile('(sk-(?:(?:proj|[a-z0-9](?:[a-z0-9-]{0,40}[a-z0-9])?)-)?[a-zA-Z0-9]{20}T3BlbkFJ[a-zA-Z0-9]{20})')
+oai_regex = re.compile('(sk-[a-zA-Z0-9-_]+T3BlbkFJ[a-zA-Z0-9-_]+)')
 anthropic_regex = re.compile(r'sk-ant-api03-[A-Za-z0-9\-_]{93}AA')
 anthropic_secondary_regex = re.compile(r'sk-ant-[A-Za-z0-9\-_]{86}')
 ai21_and_mistral_regex = re.compile('[A-Za-z0-9]{32}')


### PR DESCRIPTION
At this point there are too many variants of OpenAI keys, so it's better to just use the generic regex since the OpenAI base64'd string is always present somewhere in the key. If OpenAI adds new formats in the future, this will also catch them as long as they have the magic constant present in the key.

Examples of the newest key format:
- `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`
- `sk-svcacct-IUXtc5gIZK-2cBfB-nTgEWbD8mi-fi-gc20oGtq8ve51sET3BlbkFJCg8iQkCVz_nmE_q1dCWlMpemoaoMqHzQ6D-FnWGqlz4C8A`